### PR TITLE
shortbread: allow multi-lingual support

### DIFF
--- a/shortbread.lua
+++ b/shortbread.lua
@@ -19,14 +19,6 @@ end
 -- Tell themepark where the themes are
 themepark:add_theme_dir('themes')
 
-themepark:add_topic('core/name-with-fallback', {
-    keys = {
-        name = { 'name', 'name:en', 'name:de' },
-        name_de = { 'name:de', 'name', 'name:en' },
-        name_en = { 'name:en', 'name', 'name:de' },
-    }
-})
-
 -- --------------------------------------------------------------------------
 
 themepark:add_topic('spirit/buildings')

--- a/shortbread/boundary_labels.sql.jinja2
+++ b/shortbread/boundary_labels.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         admin_level,
         way_area
     FROM boundary_labels

--- a/shortbread/public_transport.sql.jinja2
+++ b/shortbread/public_transport.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind
     FROM public_transport
     WHERE geom && {{bbox}}

--- a/shortbread/street_labels.sql.jinja2
+++ b/shortbread/street_labels.sql.jinja2
@@ -2,12 +2,12 @@ WITH road AS (
     SELECT
         geom,
         highway AS kind,
-        name,
+        names,
         ref,
         z_order
     FROM roads
     WHERE geom && {{bbox}}
-        AND (ref IS NOT NULL OR name IS NOT NULL)
+        AND (ref IS NOT NULL OR names IS NOT NULL)
         AND highway IN
 (
 {#
@@ -25,12 +25,12 @@ rail AS (
     SELECT
         geom,
         railway AS kind,
-        NULL AS name, -- TODO: add railway names
+        NULL::jsonb AS names, -- TODO: add railway names
         ref,
         z_order
     FROM railways
     WHERE geom && {{bbox}}
-        AND (ref IS NOT NULL OR name IS NOT NULL)
+        AND (ref IS NOT NULL OR names IS NOT NULL)
         AND railway IN ('rail', 'narrow_gauge', 'tram', 'light_rail', 'funicular', 'subway', 'monorail')
 ),
 {% if zoom >=11 %}
@@ -38,7 +38,7 @@ aeroway AS (
     SELECT
         geom,
         aeroway AS kind,
-        NULL AS name,
+        NULL::jsonb AS names,
         ref,
         CASE WHEN aeroway = 'runway' THEN 510 ELSE 500 END AS z_order
     FROM aeroways
@@ -47,7 +47,7 @@ aeroway AS (
         AND aeroway IN ('runway'{% if zoom >=13 %}, 'taxiway'{% endif %})
 ),
 {% endif %}
-{% set columns = 'kind, name, ref' %}
+{% set columns = 'kind, names, ref' %}
 all_geoms AS (
 SELECT
     geom, {{columns}}, z_order
@@ -67,7 +67,7 @@ merged AS (
     SELECT
         ST_LineMerge(ST_Collect(geom)) AS geom,
         kind,
-        name,
+        names,
         string_to_array(ref, ';') AS refs,
         z_order
     FROM all_geoms
@@ -76,7 +76,7 @@ merged AS (
 SELECT
     ST_AsMVTGeom(ST_Simplify((ST_Dump(geom)).geom, {{ coordinate_length }}), {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
     kind,
-    name,
+    names,
     array_to_string(refs, E'\n') AS ref,
     array_length(refs,1) AS ref_rows,
     (SELECT MAX(char_length(ref)) FROM unnest(refs) AS u(ref)) AS ref_cols

--- a/shortbread/street_labels_points.sql.jinja2
+++ b/shortbread/street_labels_points.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind,
         ref
     FROM street_labels_points

--- a/shortbread/streets_polygons_labels.sql.jinja2
+++ b/shortbread/streets_polygons_labels.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind
     FROM streets_polygons_labels
     WHERE geom && {{bbox}}

--- a/shortbread/water_polygons_labels.sql.jinja2
+++ b/shortbread/water_polygons_labels.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind,
         way_area
     FROM water_area_labels

--- a/shortbread_original/ferries.10-14.sql.jinja2
+++ b/shortbread_original/ferries.10-14.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind
     FROM ferries
     WHERE geom && {{bbox}}

--- a/shortbread_original/place_labels.04-14.sql.jinja2
+++ b/shortbread_original/place_labels.04-14.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind,
         population
     FROM place_labels

--- a/shortbread_original/pois.14-14.sql.jinja2
+++ b/shortbread_original/pois.14-14.sql.jinja2
@@ -1,8 +1,6 @@
 SELECT
         ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         amenity,
         leisure,
         tourism,

--- a/shortbread_original/water_lines_labels.12-14.sql.jinja2
+++ b/shortbread_original/water_lines_labels.12-14.sql.jinja2
@@ -1,7 +1,5 @@
 SELECT ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-        name,
-        name_de,
-        name_en,
+        names,
         kind,
         minzoom
     FROM water_lines_labels

--- a/spirit/admin-names.sql.jinja2
+++ b/spirit/admin-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     way_area
   FROM admin
   WHERE geom && {{bbox}}

--- a/spirit/building-names.sql.jinja2
+++ b/spirit/building-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(point, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     way_area
   FROM buildings
   WHERE point && {{bbox}}

--- a/spirit/education-names.sql.jinja2
+++ b/spirit/education-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(point, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     education,
     way_area
   FROM education

--- a/spirit/food.sql.jinja2
+++ b/spirit/food.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(point, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     food
   FROM food
   WHERE point && {{bbox}}

--- a/spirit/landuse-names.sql.jinja2
+++ b/spirit/landuse-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(point, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     landuse,
     way_area
   FROM landuse

--- a/spirit/leisure-names.sql.jinja2
+++ b/spirit/leisure-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(point, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     way_area
   FROM leisure
   WHERE point && {{bbox}}

--- a/spirit/roads-high.sql.jinja2
+++ b/spirit/roads-high.sql.jinja2
@@ -1,7 +1,7 @@
 WITH all_roads AS (
 SELECT
     CASE WHEN oneway = '-1' THEN ST_Reverse(geom) ELSE geom END AS geom,
-    name,
+    names,
     ref,
     CASE -- normalize highway values
       WHEN highway IN ('motorway', 'motorway_link') THEN 'motorway'
@@ -44,13 +44,13 @@ SELECT
     geom,
 {# Omitting name and ref from small roads allows for better merging and smaller tiles #}
 {% if zoom <= 11 %}
-    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary') THEN name END AS name,
+    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary') THEN names END AS names,
     CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary') THEN COALESCE(route_ref, ref) END AS ref,
 {% elif zoom <= 12 %}
-    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN name END AS name,
+    CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN names END AS names,
     CASE WHEN highway IN ('motorway', 'trunk', 'primary', 'secondary', 'tertiary') THEN COALESCE(route_ref, ref) END AS ref,
 {% else %}
-    name,
+    names,
     COALESCE(route_ref, ref) AS ref,
 {% endif %}
     highway,
@@ -65,7 +65,7 @@ SELECT
 ), oneway_roads AS (
 SELECT
     geom, -- linemerge with geos 3.11+ when we require it
-    name,
+    names,
     highway,
     link,
     minor,
@@ -80,7 +80,7 @@ SELECT
 ), other_roads AS (
 SELECT
     ST_LineMerge(ST_Collect(geom)) AS geom,
-    name,
+    names,
     highway,
     link,
     minor,
@@ -92,18 +92,18 @@ SELECT
     z_order
   FROM reffed_roads
   WHERE oneway IS DISTINCT FROM 'yes'
-  GROUP BY name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+  GROUP BY names, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
 ), grouped_roads AS (
 SELECT
-    geom, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    geom, names, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
   FROM oneway_roads
 UNION ALL
 SELECT
-    (ST_Dump(geom)).geom AS way, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    (ST_Dump(geom)).geom AS way, names, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
   FROM other_roads
 )
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    names, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
 FROM grouped_roads
 ORDER BY z_order

--- a/spirit/settlements.sql.jinja2
+++ b/spirit/settlements.sql.jinja2
@@ -1,10 +1,9 @@
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     place
   FROM settlements
   WHERE geom && {{bbox}}
-    AND name IS NOT NULL
 {% if zoom <= 9 %}
     AND place IN ('city')
 {% elif zoom <= 10 %}

--- a/spirit/transit-points.sql.jinja2
+++ b/spirit/transit-points.sql.jinja2
@@ -1,7 +1,7 @@
 WITH transit_normalized AS (
   SELECT
     geom,
-    name,
+    names,
     station,
     mode
   FROM transit
@@ -19,7 +19,7 @@ WITH transit_normalized AS (
 )
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     station,
     mode
   FROM transit_normalized

--- a/spirit/vegetation-names.sql.jinja2
+++ b/spirit/vegetation-names.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     vegetation,
     wetland,
     way_area

--- a/spirit/water-lines.sql.jinja2
+++ b/spirit/water-lines.sql.jinja2
@@ -1,6 +1,6 @@
 SELECT
     ST_AsMVTGeom(ST_RemoveRepeatedPoints(ST_LineMerge(ST_Collect(geom)),  4*{{coordinate_length}}), {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name,
+    names,
     waterway
   FROM waterways
   WHERE geom && {{bbox}}
@@ -13,4 +13,4 @@ SELECT
 {% else %}
     AND waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
 {% endif %}
-  GROUP BY waterway, name
+  GROUP BY waterway, names

--- a/themes/shortbread/topics/boundaries.lua
+++ b/themes/shortbread/topics/boundaries.lua
@@ -7,12 +7,14 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 themepark:add_table{
     name = 'boundaries',
     ids_type = 'way',
     geom = 'linestring',
     columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'admin_level', type = 'int', not_null = true },
         { column = 'maritime', type = 'bool' },
         { column = 'disputed', type = 'bool' },
@@ -78,12 +80,12 @@ themepark:add_proc('way', function(object, data)
         return
     end
     local a = {
+        names = common.get_names(t),
         admin_level = info.admin_level,
         maritime = (t.maritime and (t.maritime == 'yes' or t.natural == 'coastline')),
         disputed = info.disputed or (t.disputed and t.disputed == 'yes'),
         geom = object:as_linestring()
     }
-    themepark.themes.core.add_name(a, object)
     themepark:insert('boundaries', a, t)
 end)
 

--- a/themes/shortbread/topics/boundary_labels.lua
+++ b/themes/shortbread/topics/boundary_labels.lua
@@ -7,12 +7,14 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 themepark:add_table{
     name = 'boundary_labels',
     ids_type = 'relation',
     geom = 'point',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'admin_level', type = 'int' },
         { column = 'way_area', type = 'real' },
         { column = 'minzoom', type = 'int', tiles = 'minzoom' },
@@ -37,9 +39,8 @@ themepark:add_proc('relation', function(object, data)
         local mgeom = object:as_multipolygon()
 
         if mgeom then
-            local a = { admin_level = admin_level }
-
-            themepark.themes.core.add_name(a, object)
+            local a = { admin_level = admin_level,
+                        names = common.get_names(object.tags) }
 
             local best_geom
             local best_area = 0

--- a/themes/shortbread/topics/ferries.lua
+++ b/themes/shortbread/topics/ferries.lua
@@ -7,12 +7,14 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 themepark:add_table{
     name = 'ferries',
     ids_type = 'way',
     geom = 'linestring',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'kind', type = 'text', not_null = true },
         { column = 'minzoom', type = 'int', tiles = 'minzoom' },
     }),
@@ -34,6 +36,7 @@ themepark:add_proc('way', function(object, data)
     if t.route == 'ferry' then
         local a = {
             kind = 'ferry',
+            names = common.get_names(object.tags),
             geom = object:as_linestring()
         }
 
@@ -43,7 +46,6 @@ themepark:add_proc('way', function(object, data)
             a.minzoom = 12
         end
 
-        themepark.themes.core.add_name(a, object)
         themepark:insert('ferries', a, t)
     end
 end)

--- a/themes/shortbread/topics/places.lua
+++ b/themes/shortbread/topics/places.lua
@@ -7,6 +7,7 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 -- ---------------------------------------------------------------------------
 
@@ -36,7 +37,8 @@ themepark:add_table{
     name = 'place_labels',
     ids_type = 'any',
     geom = 'point',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'kind', type = 'text', not_null = true },
         { column = 'population', type = 'int', not_null = true },
         { column = 'minzoom', type = 'int', not_null = true, tiles = 'minzoom' },
@@ -92,9 +94,9 @@ themepark:add_proc('node', function(object, data)
         return
     end
 
+    a.names = common.get_names(object.tags)
     a.geom = object:as_point()
 
-    themepark.themes.core.add_name(a, object)
     themepark:insert('place_labels', a, tags)
 end)
 
@@ -104,9 +106,9 @@ themepark:add_proc('area', function(object, data)
         return
     end
 
+    a.names = common.get_names(object.tags)
     a.geom = object:as_area():transform(3857):pole_of_inaccessibility()
 
-    themepark.themes.core.add_name(a, object)
     themepark:insert('place_labels', a, tags)
 end)
 -- ---------------------------------------------------------------------------

--- a/themes/shortbread/topics/pois.lua
+++ b/themes/shortbread/topics/pois.lua
@@ -7,12 +7,14 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 themepark:add_table{
     name = 'pois',
     ids_type = 'any',
     geom = 'point',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'amenity', type = 'text' },
         { column = 'leisure', type = 'text' },
         { column = 'tourism', type = 'text' },
@@ -145,7 +147,7 @@ end
 
 local get_attributes = function(object)
     local t = object.tags
-    local a = {}
+    local a = { names = common.get_names(t) }
 
     local is_poi = false
     for _, k in ipairs({'amenity', 'leisure', 'tourism', 'shop', 'man_made',
@@ -167,7 +169,6 @@ local get_attributes = function(object)
     a.housename = t['addr:housename']
     a.housenumber = t['addr:housenumber']
 
-    themepark.themes.core.add_name(a, object)
     themepark:add_debug_info(a, t)
 
     return a

--- a/themes/shortbread/topics/public_transport.lua
+++ b/themes/shortbread/topics/public_transport.lua
@@ -7,12 +7,14 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 themepark:add_table{
     name = 'public_transport',
     ids_type = 'any',
     geom = 'point',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'kind', type = 'text', not_null = true },
         { column = 'minzoom', type = 'int', tiles = 'minzoom' }
     }),
@@ -33,7 +35,7 @@ themepark:add_table{
 
 local get_attributes = function(object)
     local t = object.tags
-    local a = {}
+    local a = { names = common.get_names(t) }
 
     if t.aeroway then
         if t.aeroway == 'aerodrome' then
@@ -77,8 +79,6 @@ local get_attributes = function(object)
     else
         return nil
     end
-
-    themepark.themes.core.add_name(a, object)
 
     return a
 end

--- a/themes/shortbread/topics/sites.lua
+++ b/themes/shortbread/topics/sites.lua
@@ -7,6 +7,7 @@
 
 local themepark, theme, cfg = ...
 local expire = require('expire')
+local common = require('themes.spirit.common')
 
 -- ---------------------------------------------------------------------------
 
@@ -19,7 +20,8 @@ themepark:add_table{
     name = 'sites',
     ids_type = 'area',
     geom = 'multipolygon',
-    columns = themepark:columns('core/name', {
+    columns = themepark:columns({
+        { column = 'names', type = 'jsonb' },
         { column = 'kind', type = 'text', not_null = true },
     }),
     tags = {
@@ -43,6 +45,7 @@ local get_amenity_value = osm2pgsql.make_check_values_func(amenity_values)
 themepark:add_proc('area', function(object, data)
     local t = object.tags
     local a = {
+        names = common.get_names(t),
         kind = get_amenity_value(t.amenity)
     }
 
@@ -59,7 +62,6 @@ themepark:add_proc('area', function(object, data)
     end
 
     a.geom = object:as_area()
-    themepark.themes.core.add_name(a, object)
     themepark:insert('sites', a, t)
 end)
 

--- a/themes/spirit/common.lua
+++ b/themes/spirit/common.lua
@@ -15,4 +15,17 @@ local function layer (v)
     return nil
 end
 
-return { contains=contains, layer=layer}
+local DEFAULT_LANGUAGES = { "en", "de" }
+
+--- Returns a function to build a list of names
+local function name_selector (languages)
+    return function (tags)
+        names_found = {name=tags.name}
+        for _, lang in ipairs(languages) do
+            names_found["name_"..lang] = tags["name:"..lang]
+        end
+        return names_found
+    end
+end
+
+return { contains=contains, layer=layer, get_names=name_selector(DEFAULT_LANGUAGES)}

--- a/themes/spirit/topics/admin.lua
+++ b/themes/spirit/topics/admin.lua
@@ -6,6 +6,7 @@
 -- ---------------------------------------------------------------------------
 
 local themepark, theme, cfg = ...
+local common = require('themes.spirit.common')
 
 --- Normalizes admin_level tags
 -- @param v The admin_level tag value
@@ -25,7 +26,7 @@ themepark:add_table{
     ids_type = 'relation',
     geom = 'point', -- the primary geom used is the label, but areas are needed for admin line processing
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'admin_level', type = 'smallint'},
         { column = 'way_area', type = 'real' },
         { column = 'area', type = 'geometry'}
@@ -53,7 +54,7 @@ themepark:add_proc('area', function(object, data)
                 area = g,
                 way_area = g:area(),
                 admin_level = admin,
-                name = object.tags.name
+                names = common.get_names(object.tags)
             }
             themepark:add_debug_info(a, object.tags)
             themepark:insert('admin', a)

--- a/themes/spirit/topics/buildings.lua
+++ b/themes/spirit/topics/buildings.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'area',
     geom = 'polygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
     }),
@@ -28,10 +28,10 @@ themepark:add_proc('area', function(object, data)
     if object.tags.building and object.tags.building ~= 'no' then
         for g in object:as_area():geometries() do
             local g_transform = g:transform(3857)
-            local name = object.tags.name
-            local a = { name = name, way_area = g_transform:area(), geom = g_transform }
+            local names = common.get_names(object.tags)
+            local a = { names = names, way_area = g_transform:area(), geom = g_transform }
             -- Only add points for buildings that need labels
-            if name then
+            if next(names) ~= nil then
                 a.point = g_transform:pole_of_inaccessibility()
             end
             themepark:add_debug_info(a, object.tags)

--- a/themes/spirit/topics/education.lua
+++ b/themes/spirit/topics/education.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'any',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'education', type = 'text' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
@@ -38,7 +38,7 @@ themepark:add_proc('node', function(object, data)
     if education ~= nil then
         local a = {
             point = object:as_point(),
-            name = object.tags.name,
+            names = common.get_names(object.tags),
             education = education }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('education', a)
@@ -62,7 +62,7 @@ themepark:add_proc('area', function(object, data)
             geom = g_transform,
             point = g_transform:pole_of_inaccessibility(),
             way_area = g_transform:area(),
-            name = object.tags.name,
+            names = common.get_names(object.tags),
             education = education }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('education', a)

--- a/themes/spirit/topics/food.lua
+++ b/themes/spirit/topics/food.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'any',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'food', type = 'text' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
@@ -30,7 +30,7 @@ themepark:add_proc('node', function(object, data)
     if object.tags.amenity and common.contains(amenities, object.tags.amenity) then
         local a = {
             point = object:as_point(),
-            name = object.tags.name,
+            names = common.get_names(object.tags),
             food = object.tags.amenity }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('food', a)
@@ -44,7 +44,7 @@ themepark:add_proc('area', function(object, data)
             geom = g_transform,
             point = g_transform:pole_of_inaccessibility(),
             way_area = g_transform:area(),
-            name = object.tags.name,
+            names = common.get_names(object.tags),
             food = object.tags.amenity }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('food', a)

--- a/themes/spirit/topics/landuse.lua
+++ b/themes/spirit/topics/landuse.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'area',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'landuse', type = 'text' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
@@ -38,13 +38,14 @@ themepark:add_proc('area', function(object, data)
 
     if landuse ~= nil then
         local g_transform = object:as_area():transform(3857)
+        local names = common.get_names(object.tags)
         local a = {
-            name = object.tags.name,
+            names = names,
             landuse = landuse,
             way_area = g_transform:area(),
             geom = g_transform }
 
-        if object.tags.name then
+        if next(names) ~= nil then
             a.point = g_transform:pole_of_inaccessibility()
         end
         themepark:add_debug_info(a, object.tags)

--- a/themes/spirit/topics/leisure.lua
+++ b/themes/spirit/topics/leisure.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'area',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'leisure', type = 'text' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
@@ -36,13 +36,14 @@ themepark:add_proc('area', function(object, data)
 
     if leisure ~= nil then
         local g_transform = object:as_area():transform(3857)
+        local names = common.get_names(object.tags)
         local a = {
-            name = object.tags.name,
+            names = names,
             leisure = leisure,
             way_area = g_transform:area(),
             geom = g_transform }
 
-        if object.tags.name then
+        if next(names) ~= nil then
             a.point = g_transform:pole_of_inaccessibility()
         end
         themepark:add_debug_info(a, object.tags)

--- a/themes/spirit/topics/places.lua
+++ b/themes/spirit/topics/places.lua
@@ -15,7 +15,7 @@ themepark:add_table{
     way_area, 'real',
     geom = 'point',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'place', type = 'text' },
         { column = 'way_area', type = 'real' },
     }),
@@ -39,7 +39,7 @@ themepark:add_proc('node', function(object, data)
         local a = {
             geom = object:as_point(),
             place = place,
-            name = object.tags.name }
+            names = common.get_names(object.tags) }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('settlements', a)
     end
@@ -65,7 +65,7 @@ themepark:add_proc('area', function(object, data)
             geom = g:pole_of_inaccessibility(),
             way_area = g:area(),
             place = place,
-            name = object.tags.name }
+            names = common.get_names(object.tags) }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('settlements', a)
     end

--- a/themes/spirit/topics/railway.lua
+++ b/themes/spirit/topics/railway.lua
@@ -15,7 +15,7 @@ themepark:add_table{
     geom = 'linestring',
     columns = themepark:columns({
         { column = 'railway', type = 'text' },
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'json' },
         { column = 'ref', type = 'text' },
         { column = 'minor', type = 'boolean' },
         { column = 'bridge', type = 'boolean' },
@@ -41,7 +41,7 @@ local ssy = {'spur', 'siding', 'yard'}
 themepark:add_proc('way', function(object, data)
     local z = z_order[object.tags.railway]
     if z then
-        local a = { name = object.tags.name,
+        local a = { names = common.get_names(object.tags),
                     ref = object.tags.ref,
                     railway = object.tags.railway,
                     service = object.tags.service,

--- a/themes/spirit/topics/roads.lua
+++ b/themes/spirit/topics/roads.lua
@@ -15,7 +15,7 @@ themepark:add_table{
     geom = 'linestring',
     columns = themepark:columns({
         { column = 'highway', type = 'text' },
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'ref', type = 'text' },
         { column = 'oneway', type = 'text' },
         { column = 'minor', type = 'boolean' },
@@ -90,7 +90,7 @@ themepark:add_proc('way', function(object, data)
                 z = z_order['road']/10
             end
         end
-        local a = { name = object.tags.name,
+        local a = { names = common.get_names(object.tags),
                     highway = object.tags.highway,
                     ref = object.tags.ref,
                     oneway = object.tags.oneway,

--- a/themes/spirit/topics/transit.lua
+++ b/themes/spirit/topics/transit.lua
@@ -15,7 +15,7 @@ themepark:add_table{
     way_area, 'real',
     geom = 'point',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'station', type = 'boolean' },
         { column = 'mode', type = 'text' },
         { column = 'way_area', type = 'real' },
@@ -50,7 +50,7 @@ themepark:add_proc('node', function(object, data)
             geom = object:as_point(),
             mode = mode,
             station = station,
-            name = object.tags.name }
+            names = common.get_names(object.tags) }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('transit', a)
     end
@@ -83,7 +83,7 @@ themepark:add_proc('area', function(object, data)
             way_area = g:area(),
             mode = mode,
             station = station,
-            name = object.tags.name }
+            names = common.get_names(object.tags) }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('transit', a)
     end

--- a/themes/spirit/topics/vegetation.lua
+++ b/themes/spirit/topics/vegetation.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'area',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'vegetation', type = 'text' },
         { column = 'wetland', type = 'text' },
         { column = 'way_area', type = 'real' },
@@ -46,14 +46,15 @@ themepark:add_proc('area', function(object, data)
 
     if vegetation ~= nil then
         local g_transform = object:as_area():transform(3857)
+        local names = common.get_names(object.tags)
         local a = {
-            name = object.tags.name,
+            names = names,
             vegetation = vegetation,
             wetland = wetland,
             way_area = g_transform:area(),
             geom = g_transform }
 
-        if object.tags.name then
+        if next(names) ~= nil then
             a.point = g_transform:pole_of_inaccessibility()
         end
         themepark:add_debug_info(a, object.tags)

--- a/themes/spirit/topics/water.lua
+++ b/themes/spirit/topics/water.lua
@@ -14,7 +14,7 @@ themepark:add_table{
     ids_type = 'area',
     geom = 'multipolygon',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'way_area', type = 'real' },
         { column = 'point', type = 'point' },
     }),
@@ -28,7 +28,7 @@ themepark:add_table{
     ids_type = 'way',
     geom = 'linestring',
     columns = themepark:columns({
-        { column = 'name', type = 'text' },
+        { column = 'names', type = 'jsonb' },
         { column = 'waterway', type = 'text' },
     }),
 }
@@ -37,10 +37,10 @@ themepark:add_proc('area', function(object, data)
     if (object.tags.natural == 'water' or object.tags.waterway == 'dock' or object.tags.waterway == 'basin' or object.tags.waterway == 'reservoir')
         then
         local g_transform = object:as_area():transform(3857)
-        local name = object.tags.name
-        local a = { name = name, way_area = g_transform:area(), geom = g_transform }
+        local names = common.get_names(object.tags)
+        local a = { names = names, way_area = g_transform:area(), geom = g_transform }
         -- Only add points for water areas that need labels
-        if name then
+        if next(names) ~= nil then
             a.point = g_transform:pole_of_inaccessibility()
         end
         themepark:add_debug_info(a, object.tags)
@@ -55,7 +55,8 @@ themepark:add_proc('way', function(object, data)
         or object.tags.waterway == 'drain'
         or object.tags.waterway == 'ditch'
     ) then
-        local a = { name = object.tags.name, waterway = object.tags.waterway,
+        local a = { names = common.get_names(object.tags),
+                    waterway = object.tags.waterway,
                     geom = object:as_linestring() }
         themepark:add_debug_info(a, object.tags)
         themepark:insert('waterways', a)


### PR DESCRIPTION
This converts the name logic to a list of names rather than only en and de. Although currently only en and de are in the list it allows the list to be easily extended when the spec is changed.