### PR TITLE
Dash road casing for unpaved surfaces

### DIFF
--- a/spirit/roads-high.sql.jinja2
+++ b/spirit/roads-high.sql.jinja2
@@ -20,6 +20,9 @@ SELECT
     tunnel,
     bridge,
     layer,
+    CASE WHEN surface IN ('unpaved', 'compacted', 'fine_gravel', 'gravel', 'rock', 'pebblestone',
+                          'ground', 'dirt', 'earth', 'grass', 'mud', 'sand', 'woodchips', 'snow',
+                          'ice', 'salt', 'laterite') THEN true END AS unpaved,
     (SELECT ref FROM road_routes
       WHERE roads.way_id = road_routes.member_id
       ORDER BY cardinality(string_to_array(network, ':')) ASC, char_length(network) ASC, network, road_routes.relation_id
@@ -60,6 +63,7 @@ SELECT
     tunnel,
     bridge,
     layer,
+    unpaved,
     z_order
   FROM all_roads
 ), oneway_roads AS (
@@ -74,6 +78,7 @@ SELECT
     tunnel,
     bridge,
     layer,
+    unpaved,
     z_order
   FROM reffed_roads
   WHERE oneway = 'yes'
@@ -89,21 +94,22 @@ SELECT
     tunnel,
     bridge,
     layer,
+    unpaved,
     z_order
   FROM reffed_roads
   WHERE oneway IS DISTINCT FROM 'yes'
-  GROUP BY name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+  GROUP BY name, highway, link, minor, ref, oneway, tunnel, bridge, layer, unpaved, z_order
 ), grouped_roads AS (
 SELECT
-    geom, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    geom, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, unpaved, z_order
   FROM oneway_roads
 UNION ALL
 SELECT
-    (ST_Dump(geom)).geom AS way, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    (ST_Dump(geom)).geom AS way, name, highway, link, minor, ref, oneway, tunnel, bridge, layer, unpaved, z_order
   FROM other_roads
 )
 SELECT
     ST_AsMVTGeom(geom, {{unbuffered_bbox}}, {{extent}}, {{buffer}}) AS way,
-    name, highway, link, minor, ref, oneway, tunnel, bridge, layer, z_order
+    name, highway, link, minor, ref, oneway, tunnel, bridge, layer, unpaved, z_order
 FROM grouped_roads
 ORDER BY z_order

--- a/style/roads.glug
+++ b/style/roads.glug
@@ -172,6 +172,10 @@ layer(:road_casing, source: :spirit, source_layer: :roads) {
     'footway', '#696b67', # lch(75,3,130)
     'cycleway', '#696b67', # lch(75,3,130)
     :blue)
+
+  on(unpaved == true) {
+    line_dasharray 2, 2
+  }
 }
 
 layer(:road_fill, source: :spirit, source_layer: :roads) {


### PR DESCRIPTION
Fixes #91.

## Summary

`surface` is already extracted into the `roads` table in [themes/spirit/topics/roads.lua](https://github.com/pnorman/spirit/blob/main/themes/spirit/topics/roads.lua#L28), but it's never selected back out in [spirit/roads-high.sql.jinja2](https://github.com/pnorman/spirit/blob/main/spirit/roads-high.sql.jinja2) and [style/roads.glug](https://github.com/pnorman/spirit/blob/main/style/roads.glug) has no surface-based rules, so a `highway=residential` with `surface=asphalt` and one with `surface=ground` render identically.

## Changes

- `spirit/roads-high.sql.jinja2`: add an `unpaved` boolean derived from `surface` in the `all_roads` CTE, threaded through `reffed_roads`, `oneway_roads`, `other_roads`, `grouped_roads`, and the final `SELECT`/`GROUP BY`. The classification list (`unpaved`, `compacted`, `fine_gravel`, `gravel`, `rock`, `pebblestone`, `ground`, `dirt`, `earth`, `grass`, `mud`, `sand`, `woodchips`, `snow`, `ice`, `salt`, `laterite`) mirrors how other general-purpose styles (e.g. OSM Carto) group unpaved surface values.
- `style/roads.glug`: dash the `road_casing` layer's casing (`on(unpaved == true) { line_dasharray 2, 2 }`) when `unpaved` is true.

Scoped to `road_casing` (the non-bridge/non-tunnel casing layer) only. `road_base_casing` already overrides `line_dasharray` for tunnels via its own `on(tunnel == true)` block, and I didn't want to guess how a tunnel dash and an unpaved dash should compose without being able to render tiles and look at it, so bridge/tunnel roads are left out of scope here. Happy to extend to those layers if a maintainer has a preference on how that should look.

## Testing

I don't have a running instance of this style to render tiles against, so the dash pattern (`2, 2`) and the unpaved classification list are unverified visually. Please treat those as a starting point rather than a final call, happy to adjust based on how it actually looks.